### PR TITLE
Configure Nextcloud stack for HTTPS via NGINX and Certbot

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,2 @@
+NEXTCLOUD_DOMAIN=cloud.example.com
+LETSENCRYPT_EMAIL=admin@example.com

--- a/README.md
+++ b/README.md
@@ -9,19 +9,55 @@ Dieser Testserver nutzt mehrere Container, um möglichst viele Nextcloud-Funktio
 - **Nextcloud** (App & Cron)
 - **MariaDB** Datenbank
 - **Redis** für Caching
-- **notify_push** für Push-Benachrichtigungen
+- **NGINX** Reverse Proxy
+- **Certbot** für Let's-Encrypt-Zertifikate
 - **OnlyOffice** Dokumentenserver
 - **Collabora Online**
 
-### Starten
+### Vorbereitung
+
+1. Kopiere die Beispieldatei und passe Domain sowie E-Mail-Adresse an:
+
+   ```bash
+   cp .env.example .env
+   # .env editieren und NEXTCLOUD_DOMAIN sowie LETSENCRYPT_EMAIL setzen
+   ```
+
+   Die Domain muss bereits öffentlich erreichbar sein und per DNS auf den Server zeigen, damit Let's Encrypt ein Zertifikat ausstellen kann.
+
+2. Starte die Container im Hintergrund:
+
+   ```bash
+   docker compose up -d
+   ```
+
+3. Beantrage das erste TLS-Zertifikat (ersetze die Platzhalter aus deiner `.env` Datei):
+
+   ```bash
+   docker compose run --rm certbot certonly \
+     --webroot -w /var/www/certbot \
+     -d "$NEXTCLOUD_DOMAIN" \
+     --email "$LETSENCRYPT_EMAIL" \
+     --agree-tos --no-eff-email
+   ```
+
+4. Lade anschließend die NGINX-Konfiguration neu, damit das Zertifikat genutzt wird:
+
+   ```bash
+   docker compose exec nginx nginx -s reload
+   ```
+
+Certbot kümmert sich danach automatisch um die Verlängerung (`certbot`-Service führt regelmäßig `certbot renew` aus). Nach einer erfolgreichen Verlängerung muss der NGINX-Container einmal neu geladen werden, z. B. per Cronjob:
 
 ```bash
-docker compose up -d
+docker compose exec nginx nginx -s reload
 ```
 
-Der Webzugriff erfolgt anschließend über [http://localhost:8080](http://localhost:8080).
+### Zugriff
 
-Weitere Dienste:
+Der Webzugriff erfolgt anschließend über `https://<deine-domain>`.
+
+Weitere Dienste (weiterhin unverschlüsselt im lokalen Netz erreichbar):
+
 - OnlyOffice: Port 8081
 - Collabora: Port 9980
-- Push-Server: Port 7867

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,8 +22,6 @@ services:
   app:
     image: nextcloud:latest
     restart: unless-stopped
-    ports:
-      - 8080:80
     depends_on:
       - db
       - redis
@@ -33,8 +31,14 @@ services:
       - MYSQL_USER=nextcloud
       - MYSQL_HOST=db
       - REDIS_HOST=redis
+      - NEXTCLOUD_TRUSTED_DOMAINS=${NEXTCLOUD_DOMAIN}
+      - OVERWRITEHOST=${NEXTCLOUD_DOMAIN}
+      - OVERWRITEPROTOCOL=https
     volumes:
       - nextcloud_data:/var/www/html
+    networks:
+      - default
+      - proxy
 
   cron:
     image: nextcloud:latest
@@ -51,6 +55,35 @@ services:
       - REDIS_HOST=redis
     volumes:
       - nextcloud_data:/var/www/html
+
+  nginx:
+    build: ./nginx
+    restart: unless-stopped
+    depends_on:
+      - app
+    environment:
+      - NEXTCLOUD_DOMAIN=${NEXTCLOUD_DOMAIN}
+    ports:
+      - 80:80
+      - 443:443
+    volumes:
+      - certbot_etc:/etc/letsencrypt
+      - certbot_var:/var/lib/letsencrypt
+      - certbot_challenges:/var/www/certbot
+      - nginx_logs:/var/log/nginx
+    networks:
+      - proxy
+      - default
+
+  certbot:
+    image: certbot/certbot:latest
+    restart: unless-stopped
+    volumes:
+      - certbot_etc:/etc/letsencrypt
+      - certbot_var:/var/lib/letsencrypt
+      - certbot_challenges:/var/www/certbot
+    entrypoint: /bin/sh
+    command: -c "trap exit TERM; while :; do certbot renew --webroot -w /var/www/certbot; sleep 12h & wait $${!}; done"
 
   onlyoffice:
     image: onlyoffice/documentserver:latest
@@ -70,3 +103,11 @@ volumes:
   db_data:
   redis_data:
   nextcloud_data:
+  certbot_etc:
+  certbot_var:
+  certbot_challenges:
+  nginx_logs:
+
+networks:
+  proxy:
+    driver: bridge

--- a/nginx/Dockerfile
+++ b/nginx/Dockerfile
@@ -1,0 +1,8 @@
+FROM nginx:alpine
+
+RUN apk add --no-cache gettext
+
+COPY conf.d/nextcloud.conf.template /etc/nginx/templates/nextcloud.conf.template
+COPY entrypoint.sh /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/nginx/conf.d/nextcloud.conf.template
+++ b/nginx/conf.d/nextcloud.conf.template
@@ -1,0 +1,48 @@
+server {
+    listen 80;
+    listen [::]:80;
+    server_name ${NEXTCLOUD_DOMAIN};
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+
+    location / {
+        return 301 https://$host$request_uri;
+    }
+}
+
+server {
+    listen 443 ssl http2;
+    listen [::]:443 ssl http2;
+    server_name ${NEXTCLOUD_DOMAIN};
+
+    ssl_certificate /etc/letsencrypt/live/${NEXTCLOUD_DOMAIN}/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/${NEXTCLOUD_DOMAIN}/privkey.pem;
+    include /etc/letsencrypt/options-ssl-nginx.conf;
+    ssl_dhparam /etc/letsencrypt/ssl-dhparams.pem;
+
+    client_max_body_size 512M;
+    add_header Strict-Transport-Security "max-age=15768000; includeSubDomains" always;
+
+    location / {
+        proxy_pass http://app:80;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+        proxy_buffering off;
+    }
+
+    location /.well-known/carddav {
+        return 301 $scheme://$host/remote.php/dav;
+    }
+
+    location /.well-known/caldav {
+        return 301 $scheme://$host/remote.php/dav;
+    }
+
+    location /.well-known/acme-challenge/ {
+        root /var/www/certbot;
+    }
+}

--- a/nginx/entrypoint.sh
+++ b/nginx/entrypoint.sh
@@ -1,0 +1,11 @@
+#!/bin/sh
+set -eu
+
+if [ -z "${NEXTCLOUD_DOMAIN:-}" ]; then
+    echo "Environment variable NEXTCLOUD_DOMAIN must be set" >&2
+    exit 1
+fi
+
+envsubst '${NEXTCLOUD_DOMAIN}' < /etc/nginx/templates/nextcloud.conf.template > /etc/nginx/conf.d/nextcloud.conf
+
+exec nginx -g 'daemon off;'


### PR DESCRIPTION
## Summary
- add an NGINX reverse proxy image that templates the TLS configuration for the configured Nextcloud domain
- introduce a Certbot service, shared certificate volumes, and environment variables required for HTTPS termination
- document the HTTPS bootstrap procedure and provide an example .env file for domain and email settings

## Testing
- not run (infrastructure configuration only)


------
https://chatgpt.com/codex/tasks/task_b_68d65917cf6083259e5da4e8c2de01e1